### PR TITLE
send load_successful on start rather than finish of preload, to avoid…

### DIFF
--- a/PILT.js
+++ b/PILT.js
@@ -21,7 +21,7 @@ const preload_PILT = {
     data: {
         trialphase: "preload_PILT"
     },
-    on_finish: () => {
+    on_start: () => {
 
         // Report to tests
         console.log("load_successful")
@@ -43,7 +43,7 @@ const preload_wm_ltm = {
     data: {
         trialphase: "preload_WM_LTM"
     },
-    on_finish: () => {
+    on_start: () => {
 
         // Report to tests
         console.log("load_successful")

--- a/build_control_timeline.js
+++ b/build_control_timeline.js
@@ -29,7 +29,7 @@ const controlPreload = {
   data: {
     trialphase: "control_preload"
   },
-  on_finish: () => {
+  on_start: () => {
     // Report to tests
     console.log("load_successful")
 

--- a/reversal.js
+++ b/reversal.js
@@ -22,7 +22,7 @@ const reversal_preload = {
         trialphase: "reversal_preload"
     },
     continue_after_error: true,
-    on_finish: () => {
+    on_start: () => {
         // Report to tests
         console.log("load_successful")
 

--- a/vigour.js
+++ b/vigour.js
@@ -35,7 +35,7 @@ const preload_vigour = {
   data: {
       trialphase: "preload_PILT"
   },
-  on_finish: () => {
+  on_start: () => {
 
       // Report to tests
       console.log("load_successful")


### PR DESCRIPTION
… timeouts