### PR TITLE
304 the resumption is not working for questionnaire modules

### DIFF
--- a/questionnaires.js
+++ b/questionnaires.js
@@ -205,7 +205,7 @@ var questionnaire_phq = (i,total) => {
             trialphase: "PHQ"
         },
         on_start: () => {
-            updateState("PHQ_start");
+            updateState("PHQ9_start");
         }
     };
 };
@@ -223,7 +223,7 @@ var questionnaire_gad = (i,total) => {
             trialphase: "GAD"
         },
         on_start: () => {
-            updateState("GAD_start");
+            updateState("GAD7_start");
         }
     };
 };
@@ -345,7 +345,7 @@ var questionnaire_pvss = (i,total) => {
             trialphase: "PVSS"
         },
         on_start: () => {
-            updateState("pvss_start");
+            updateState("PVSS_start");
         }
     };
 };

--- a/validation/questionnaires/README.md
+++ b/validation/questionnaires/README.md
@@ -182,4 +182,4 @@
             <td>BFI_Q8</td><td>I see myself as someone who gets nervous easily</td>
         </tr><tr>
             <td>BFI_Q9</td><td>I see myself as someone who has an active imagination</td>
-        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table><!-- END Validation Report -->
+        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table><!-- END Validation Report -->


### PR DESCRIPTION
Solve #304 
Tested for screening session and wk4
----
This pull request updates state identifiers in the `questionnaires.js` file for consistency and makes a minor formatting adjustment in the `README.md` file under `validation/questionnaires`. Below are the key changes:

### Updates to state identifiers for consistency:

* Updated the state identifier from `"PHQ_start"` to `"PHQ9_start"` in the `questionnaire_phq` function. (`questionnaires.js`, [questionnaires.jsL208-R208](diffhunk://#diff-cbaaa2064e293c3a02d06e546066164b0216b5de5e9eab1d98886a68872ef1a6L208-R208))
* Updated the state identifier from `"GAD_start"` to `"GAD7_start"` in the `questionnaire_gad` function. (`questionnaires.js`, [questionnaires.jsL226-R226](diffhunk://#diff-cbaaa2064e293c3a02d06e546066164b0216b5de5e9eab1d98886a68872ef1a6L226-R226))
* Updated the state identifier from `"pvss_start"` to `"PVSS_start"` in the `questionnaire_pvss` function. (`questionnaires.js`, [questionnaires.jsL348-R348](diffhunk://#diff-cbaaa2064e293c3a02d06e546066164b0216b5de5e9eab1d98886a68872ef1a6L348-R348))

### Minor formatting adjustment:

* Adjusted redundant table closing tags in the `README.md` file for better formatting. (`validation/questionnaires/README.md`, [validation/questionnaires/README.mdL185-R185](diffhunk://#diff-d2124d58da00528db3008a3c4ff7d9c42412c9a37a0b9c5b32d6db93e295dc03L185-R185))