### PR TITLE
fix(task): remove obsolete vigour/pit bonus trial

### DIFF
--- a/experiment.html
+++ b/experiment.html
@@ -355,12 +355,6 @@
                 ]);
             }
 
-            if (resumptionRule(pilt_to_test_order, window.last_state, "vigour_pit_bonus_start")) {
-                // Add vigour bonus message
-                console.log("Adding vigour bonus");
-                procedure.push(vigour_PIT_bonus2);
-            }
-
             if (resumptionRule(pilt_to_test_order, window.last_state, "vigour_test_task_start")) {
                 // Add post-vigour test
                 console.log("Adding post-vigour test");

--- a/resumption.js
+++ b/resumption.js
@@ -72,7 +72,6 @@ pilt_to_test_order = pilt_to_test_order.concat([
     "vigour_task_start",
     "pit_instructions_start",
     "pit_task_start",
-    "vigour_pit_bonus_start",
     `vigour_test_task_start`,
     "pilt_test_instructions_start",
     "pilt_test_task_start",


### PR DESCRIPTION
RE #311: It's an old code.

- Since we're using fractional bonus now, it's coherent across different tasks, therefore no need to single out Vigour/PIT bonus

- It's not directly relevant to the final bonus either, since the bonus should be at the end of module only

----
This pull request removes the "vigour PIT bonus" functionality from the experiment workflow, simplifying the procedure and associated code. The most important changes involve removing the related conditional logic and references to the bonus step.

### Removal of "vigour PIT bonus" functionality:

* [`experiment.html`](diffhunk://#diff-e5682663ae71b50e04c43bc439cdaf8f99ff1cd8514af51e7811027a28a00b2cL358-L363): Removed the conditional logic that added the "vigour PIT bonus" step to the procedure, including the associated console log and reference to `vigour_PIT_bonus2`.
* [`resumption.js`](diffhunk://#diff-1ebd4b31f0e52fadbc8dd7955cdb36461d64eeb01673b356a18858f5fc3babd5L75): Removed the "vigour_pit_bonus_start" entry from the `pilt_to_test_order` array, ensuring it is no longer part of the experiment workflow.