### PR TITLE
fix(task): correct PILT bonus calculation 

### DIFF
--- a/PILT.js
+++ b/PILT.js
@@ -586,7 +586,7 @@ function return_PILT_full_sequence() {
 
 const earnedSumPILT = () => {
     // Compute the actual sum of coins
-    const earned_sum = jsPsych.data.get().filter({trial_type: "PILT"}).select("chosen_feedback").sum();
+    const earned_sum = jsPsych.data.get().filter({trial_type: "PILT"}).filterCustom((trial) => {return typeof trial["block"] === "number"}).select("chosen_feedback").sum();
 
     return earned_sum
 }


### PR DESCRIPTION
Fix earnedSumPILT function to avoid earned being larger than max bonus, particularly when participants earn more than 0 from practice trials

remove the non-number block trials (e.g., trials with the same plugin but in practice)

----
This pull request includes a refinement to the `earnedSumPILT` function in the `PILT.js` file. The change improves data filtering by adding a custom condition to ensure trials have a numeric `block` property before summing the `chosen_feedback` values.

* [`PILT.js`](diffhunk://#diff-4729952e36a7f229c244d2c0b58fd24150378eb1c3200984d777bb5600f3fad4L589-R589): Updated the `earnedSumPILT` function to include a `filterCustom` condition that checks if the `block` property is a number, enhancing the accuracy of the data filtering process.