### PR TITLE
fix: correct minor typos in questionnaire prompts

### DIFF
--- a/questionnaires.js
+++ b/questionnaires.js
@@ -194,7 +194,7 @@ var questionnaire_phq = (i,total) => {
             "Feeling tired or having little energy",
             "Poor appetite or overeating",
             "Feeling bad about yourself - or that you are a failure or have let yourself or your family down",
-            "Trouble concentrating on things, such as reading the newspaper of watching television",
+            "Trouble concentrating on things, such as reading the newspaper or watching television",
             "Moving or speaking so slowly that other people have noticed, or the opposite - being so fidgety or restless that you have been moving around a lot more than usual",
             "Experiencing sadness or a sense of despair", // Catch
             "Thoughts that you would be better off dead, or of hurting yourself in some way",
@@ -214,7 +214,7 @@ var questionnaire_gad = (i,total) => {
     return {
         type: jsPsychSurveyTemplate,
         instructions: [`<h2>Questionnaire ${i} out of ${total}</h2>` +
-            "<p>Over the <u>last 2 weeks</u>, how often have you been bothered by following problems?</p>"
+            "<p>Over the <u>last 2 weeks</u>, how often have you been bothered by the following problems?</p>"
         ],
         items: prompt_gad,
         scale: likert_gad,

--- a/validation/questionnaires/README.md
+++ b/validation/questionnaires/README.md
@@ -20,7 +20,7 @@
         </tr><tr>
             <td>PHQ9_Q5</td><td>Feeling bad about yourself - or that you are a failure or have let yourself or your family down</td>
         </tr><tr>
-            <td>PHQ9_Q6</td><td>Trouble concentrating on things, such as reading the newspaper of watching television</td>
+            <td>PHQ9_Q6</td><td>Trouble concentrating on things, such as reading the newspaper or watching television</td>
         </tr><tr>
             <td>PHQ9_Q7</td><td>Moving or speaking so slowly that other people have noticed, or the opposite - being so fidgety or restless that you have been moving around a lot more than usual</td>
         </tr><tr>
@@ -182,4 +182,4 @@
             <td>BFI_Q8</td><td>I see myself as someone who gets nervous easily</td>
         </tr><tr>
             <td>BFI_Q9</td><td>I see myself as someone who has an active imagination</td>
-        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table><!-- END Validation Report -->
+        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table>        </tr></table><!-- END Validation Report -->


### PR DESCRIPTION
This pull request makes minor text corrections to questionnaire prompts in `questionnaires.js` to improve clarity and fix typographical errors.

- Questionnaire prompt corrections:
  * Fixed a typo in the PHQ questionnaire prompt, changing "reading the newspaper **of** watching television" to "reading the newspaper **or** watching television".
  * Clarified the GAD questionnaire instructions by adding "the" before "following problems".

Close #331 